### PR TITLE
Fixed wire door status, it did not update

### DIFF
--- a/lua/entities/sbep_base_door_controller/init.lua
+++ b/lua/entities/sbep_base_door_controller/init.lua
@@ -62,7 +62,7 @@ function ENT:AddDoors()
 			D:Initialize()
 			D:SetDoorType( Data.type )
 			D:Attach( self , Data.V , Data.A )
-		D:SetController( self , k )
+			D:SetController( self , n )
 		table.insert( self.DT , D )
 	end
 end


### PR DESCRIPTION
The wire status for all door outputs (open_X) did not update because of a wrong var.
